### PR TITLE
Skip tests where relevant

### DIFF
--- a/tests/pipelines/glm_image/test_glm_image.py
+++ b/tests/pipelines/glm_image/test_glm_image.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
 import unittest
 
 import numpy as np
@@ -27,7 +26,7 @@ from transformers import (
 
 from diffusers import AutoencoderKL, FlowMatchEulerDiscreteScheduler, GlmImagePipeline, GlmImageTransformer2DModel
 
-from ...testing_utils import enable_full_determinism, require_transformers_version_greater, require_torch_accelerator
+from ...testing_utils import enable_full_determinism, require_torch_accelerator, require_transformers_version_greater
 from ..pipeline_params import TEXT_TO_IMAGE_BATCH_PARAMS, TEXT_TO_IMAGE_IMAGE_PARAMS, TEXT_TO_IMAGE_PARAMS
 from ..test_pipelines_common import PipelineTesterMixin
 
@@ -168,7 +167,7 @@ class GlmImagePipelineFastTests(PipelineTesterMixin, unittest.TestCase):
         image = pipe(**inputs).images[0]
         generated_slice = image.flatten()
         generated_slice = np.concatenate([generated_slice[:8], generated_slice[-8:]])
-        
+
         # fmt: off
         expected_slice = np.array(
             [
@@ -197,13 +196,11 @@ class GlmImagePipelineFastTests(PipelineTesterMixin, unittest.TestCase):
     @unittest.skip("Needs to be revisited.")
     def test_pipeline_level_group_offloading_inference(self):
         pass
-    
-    @unittest.skip("Follow set of tests are relaxed because this pipeline doesn't guarantee same outputs for the same inputs in consecutive runs.")
-    def test_dict_tuple_outputs_equivalent(self):
-        pass
 
-    @unittest.skip("Skipped")
-    def test_float16_inference(self):
+    @unittest.skip(
+        "Follow set of tests are relaxed because this pipeline doesn't guarantee same outputs for the same inputs in consecutive runs."
+    )
+    def test_dict_tuple_outputs_equivalent(self):
         pass
 
     @unittest.skip("Skipped")


### PR DESCRIPTION
# What does this PR do?

Some tests are still failing:

```bash
FAILED tests/pipelines/glm_image/test_glm_image.py::GlmImagePipelineFastTests::test_pipeline_call_signature - AssertionError: False is not true : Required parameters not present: {'negative_prompt'}

FAILED tests/pipelines/glm_image/test_glm_image.py::GlmImagePipelineFastTests::test_model_cpu_offload_forward_pass - RuntimeError: Expected all tensors to be on the same device, but got index is on cpu, different from other tensors on cuda:0 (when che...

FAILED tests/pipelines/glm_image/test_glm_image.py::GlmImagePipelineFastTests::test_sequential_cpu_offload_forward_pass - NotImplementedError: Cannot copy out of meta tensor; no data!

FAILED tests/pipelines/glm_image/test_glm_image.py::GlmImagePipelineFastTests::test_sequential_offload_forward_pass_twice - NotImplementedError: Cannot copy out of meta tensor; no data!


FAILED tests/pipelines/glm_image/test_glm_image.py::GlmImagePipelineFastTests::test_cpu_offload_forward_pass_twice - RuntimeError: Expected all tensors to be on the same device, but got index is on cpu, different from other tensors on cuda:0 (when che...
```

Will look into.

Additionally, this PR sets the test suite to run only when a specific `transformers` version is available and a GPU is available as the tests are a bit heavy to run on a PR.